### PR TITLE
Mejoras de comentarios.

### DIFF
--- a/internal/commands/cmd_root.go
+++ b/internal/commands/cmd_root.go
@@ -7,10 +7,6 @@ import (
 func init() {
 	CmdRoot.AddCommand(cmdAutocomplete)
 	CmdRoot.AddCommand(cmdClone)
-	cmdClone.Flags().StringVarP(&org, "org", "o", "", "Organizacion de Github (requerido)")
-	cmdClone.MarkFlagRequired("org")
-	cmdClone.Flags().StringVarP(&pattern, "pattern", "p", "", "Prefijo de los proyectos a clonar (requerido)")
-	cmdClone.MarkFlagRequired("pattern")
 }
 
 var CmdRoot = &cobra.Command{


### PR DESCRIPTION
Elimina los comentarios en el código.
Sustituye la sentencia goto.
Cambia la forma de tratar los errores.
Las etiquetas del comando clone ahora están implementadas en cmd_clone.